### PR TITLE
Add extended key usage

### DIFF
--- a/examples/Gimlet_RoT_Stage0_Code_Signing/config.kdl
+++ b/examples/Gimlet_RoT_Stage0_Code_Signing/config.kdl
@@ -411,5 +411,8 @@ certificate "TEST USE ONLY - Gimlet RoT Stage0 Code Signing Production Online Si
             key-id
             issuer
         }
+        extended-key-usage critical=false {
+            id-kp-client-auth
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,7 @@ pub enum X509Extensions {
     KeyUsage(KeyUsageExtension),
     SubjectKeyIdentifier(SubjectKeyIdentifierExtension),
     AuthorityKeyIdentifier(AuthorityKeyIdentifierExtension),
+    ExtendedKeyUsage(ExtendedKeyUsageExtension),
 }
 
 #[derive(knuffel::Decode, Debug)]
@@ -145,6 +146,30 @@ pub struct KeyUsageExtension {
 
     #[knuffel(child)]
     pub decipher_only: bool,
+}
+
+#[derive(knuffel::Decode, Debug)]
+pub struct ExtendedKeyUsageExtension {
+    #[knuffel(property)]
+    pub critical: bool,
+
+    #[knuffel(child)]
+    pub id_kp_server_auth: bool,
+
+    #[knuffel(child)]
+    pub id_kp_client_auth: bool,
+
+    #[knuffel(child)]
+    pub id_kp_code_signing: bool,
+
+    #[knuffel(child)]
+    pub id_kp_email_protection: bool,
+
+    #[knuffel(child)]
+    pub id_kp_time_stamping: bool,
+
+    #[knuffel(child)]
+    pub id_kp_ocspsigning: bool,
 }
 
 #[derive(knuffel::Decode, Debug)]
@@ -235,7 +260,7 @@ pub fn load_and_validate(path: &std::path::Path) -> Result<Document> {
                         cert.name,
                         cert.issuer_key
                     )
-                }        
+                }
             }
             (None, Some(cert_name)) => {
                 if let None = cert_names.get(cert_name.as_str()) {


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/pki-playground/issues/3

This currently doesn't actually work and seems to fail if I add this to a cert 

See https://github.com/oxidecomputer/pki-playground/pull/4/commits/acf2550546f3fd6301bdebc5386bec156e7c45b8#diff-33af558753e6a6c431cf99fd8f11fb026226a5f6767c6e782749259c5d993f1e

```
Error: 
  × signing cert
  ╰─▶ message too long

```