### PR TITLE
Allow the Sha_256 name

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,7 @@ pub struct Certificate {
 
 #[derive(knuffel::DecodeScalar, Debug)]
 pub enum DigestAlgorithm {
+    #[allow(non_camel_case_types)]
     Sha_256,
 }
 


### PR DESCRIPTION
The name of a variable causes a warning. Lets disable that 
```
warning: variant `Sha_256` should have an upper camel case name
  --> src/config.rs:97:5
   |
97 |     Sha_256,
   |     ^^^^^^^ help: convert the identifier to upper camel case: `Sha256`
   |
   = note: `#[warn(non_camel_case_types)]` on by default

warning: `pki-playground` (lib) generated 1 warning
```