### PR TITLE
add path-len to basic-constraints

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,9 @@ pub struct BasicConstraintsExtension {
 
     #[knuffel(property)]
     pub ca: bool,
+
+    #[knuffel(property)]
+    pub path_len: Option<u8>,
 }
 
 #[derive(knuffel::Decode, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ impl BasicConstraintsExtension {
     pub fn from_config(config: &config::BasicConstraintsExtension) -> Result<Self> {
         let der = BasicConstraints {
             ca: config.ca,
-            path_len_constraint: None,
+            path_len_constraint: config.path_len,
         }
         .to_vec()
         .into_diagnostic()?;


### PR DESCRIPTION
Add support for path-len in basic constraints
```
...
    not-after "9999-12-31T23:59:59Z"
    extensions {
        basic-constraints critical=true ca=true path-len=0
	subject-key-identifier critical=false
        key-usage critical=true {
...
```