### PR TITLE
Add a simple client server example config file

### DIFF
--- a/examples/simple-chain-client-server/config.kdl
+++ b/examples/simple-chain-client-server/config.kdl
@@ -1,0 +1,172 @@
+key-pair "TEST USE ONLY - Test CA A" {
+    rsa num-bits=4096
+}
+
+entity "TEST USE ONLY - Test CA A" {
+    country-name "UK"
+    state-or-province-name "England"
+    locality-name "London"
+    organization-name "Fun"
+    organizational-unit-name "Test"
+    common-name "TEST USE ONLY - Test CA A"
+}
+
+
+key-pair "TEST USE ONLY - Test Int A" {
+    rsa num-bits=4096
+}
+
+entity "TEST USE ONLY - Test Int A" {
+    country-name "UK"
+    state-or-province-name "England"
+    locality-name "London"
+    organization-name "Fun"
+    organizational-unit-name "Test"
+    common-name "TEST USE ONLY - Test Int A"
+}
+
+
+key-pair "TEST USE ONLY - Test Int B" {
+    rsa num-bits=4096
+}
+
+entity "TEST USE ONLY - Test Int B" {
+    country-name "UK"
+    state-or-province-name "England"
+    locality-name "London"
+    organization-name "Fun"
+    organizational-unit-name "Test"
+    common-name "TEST USE ONLY - Test Int B"
+}
+
+key-pair "TEST USE ONLY - Test Server A" {
+    rsa num-bits=4096
+}
+
+entity "TEST USE ONLY - Test Server A" {
+    country-name "UK"
+    state-or-province-name "England"
+    locality-name "London"
+    organization-name "Fun"
+    organizational-unit-name "Test"
+    common-name "TEST USE ONLY - Test Server A"
+}
+
+key-pair "TEST USE ONLY - Test Client A" {
+    rsa num-bits=4096
+}
+
+entity "TEST USE ONLY - Test Client A" {
+    country-name "UK"
+    state-or-province-name "England"
+    locality-name "London"
+    organization-name "Fun"
+    organizational-unit-name "Test"
+    common-name "TEST USE ONLY - Test Client A"
+}
+
+
+certificate "TEST USE ONLY - Test CA A" {
+    subject-entity "TEST USE ONLY - Test CA A"
+    subject-key "TEST USE ONLY - Test CA A"
+    issuer-entity "TEST USE ONLY - Test CA A"
+    issuer-key "TEST USE ONLY - Test CA A"
+    digest-algorithm "sha-256"
+
+    not-after "9999-12-31T23:59:59Z"
+    extensions {
+        basic-constraints critical=true ca=true
+        subject-key-identifier critical=false
+        key-usage critical=true {
+            key-cert-sign
+            digital-signature
+            key-encipherment
+            data-encipherment
+            key-agreement
+            crl-sign
+        }
+        extended-key-usage critical=false {
+            id-kp-client-auth
+            id-kp-server-auth	    
+        }
+    }
+    serial-number 1
+}
+
+
+certificate "TEST USE ONLY - Test Int A" {
+    subject-entity "TEST USE ONLY - Test Int A"
+    subject-key "TEST USE ONLY - Test Int A"
+    issuer-key "TEST USE ONLY - Test CA A"
+    issuer-certificate "TEST USE ONLY - Test CA A"
+    digest-algorithm "sha-256"
+
+    not-after "9999-12-31T23:59:59Z"
+    extensions {
+        basic-constraints critical=true ca=true path-len=0
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false{
+            key-id
+        }
+        key-usage critical=true {
+            key-cert-sign
+            digital-signature
+            key-encipherment
+            data-encipherment
+            key-agreement
+            crl-sign
+        }
+        extended-key-usage critical=false {
+            id-kp-client-auth
+            id-kp-server-auth	    
+        }
+    }	
+    serial-number 1
+}
+
+
+certificate "TEST USE ONLY - Test Server A" {
+    subject-entity "TEST USE ONLY - Test Server A"
+    subject-key "TEST USE ONLY - Test Server A"
+    issuer-certificate "TEST USE ONLY - Test Int A"
+    issuer-key "TEST USE ONLY - Test Int A"
+    digest-algorithm "sha-256"
+
+    not-after "9999-12-31T23:59:59Z"
+    extensions {
+        basic-constraints critical=true ca=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+        extended-key-usage critical=false {
+            id-kp-server-auth
+        }
+    }
+
+    serial-number 1
+}
+
+
+certificate "TEST USE ONLY - Test Client A" {
+    subject-entity "TEST USE ONLY - Test Client A"
+    subject-key "TEST USE ONLY - Test Client A"
+    issuer-certificate "TEST USE ONLY - Test Int A"
+    issuer-key "TEST USE ONLY - Test Int A"
+    digest-algorithm "sha-256"
+
+    not-after "9999-12-31T23:59:59Z"
+    extensions {
+        basic-constraints critical=true ca=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+        extended-key-usage critical=false {
+            id-kp-client-auth
+        }
+    }
+
+    serial-number 1
+}
+
+
+


### PR DESCRIPTION
This adds an example client server certs but really the tool needs to support `Subject Alternative Name` ( https://github.com/oxidecomputer/pki-playground/issues/11 ) to make the examples better.