### PR TITLE
Add support for CSR generation.

### DIFF
--- a/examples/simple-chain-client-server/config.kdl
+++ b/examples/simple-chain-client-server/config.kdl
@@ -124,6 +124,11 @@ certificate "TEST USE ONLY - Test Int A" {
     serial-number "01"
 }
 
+certificate-request "TEST USE ONLY - Test CSR A" {
+    subject-entity "TEST USE ONLY - Test Server A"
+    subject-key "TEST USE ONLY - Test Server A"
+    digest-algorithm "sha-256"
+}
 
 certificate "TEST USE ONLY - Test Server A" {
     subject-entity "TEST USE ONLY - Test Server A"

--- a/examples/simple-chain-client-server_ed25519/config.kdl
+++ b/examples/simple-chain-client-server_ed25519/config.kdl
@@ -65,6 +65,10 @@ entity "TEST USE ONLY - Test Client A" {
     common-name "TEST USE ONLY - Test Client A"
 }
 
+certificate-request "TEST USE ONLY - Test Server A" {
+    subject-entity "TEST USE ONLY - Test Server A"
+    subject-key "TEST USE ONLY - Test Server A"
+}
 
 certificate "TEST USE ONLY - Test CA A" {
     subject-entity "TEST USE ONLY - Test CA A"

--- a/examples/simple-chain-client-server_p384/config.kdl
+++ b/examples/simple-chain-client-server_p384/config.kdl
@@ -11,7 +11,6 @@ entity "TEST USE ONLY - Test CA A" {
     common-name "TEST USE ONLY - Test CA A"
 }
 
-
 key-pair "TEST USE ONLY - Test Int A" {
     p384
 }
@@ -152,6 +151,12 @@ certificate "TEST USE ONLY - Test Int B" {
         }
     }
     serial-number "01"
+}
+
+certificate-request "TEST USE ONLY - Test CSR A" {
+    subject-entity "TEST USE ONLY - Test Server A"
+    subject-key "TEST USE ONLY - Test Server A"
+    digest-algorithm "sha-256"
 }
 
 certificate "TEST USE ONLY - Test Server A" {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,9 @@ pub struct Document {
 
     #[knuffel(children(name = "certificate"))]
     pub certificates: Vec<Certificate>,
+
+    #[knuffel(children(name = "certificate-request"))]
+    pub certificate_requests: Vec<CertificateRequest>,
 }
 
 #[derive(knuffel::Decode, Debug)]
@@ -92,6 +95,19 @@ pub struct Certificate {
 
     #[knuffel(child, unwrap(children))]
     pub extensions: Vec<X509Extensions>,
+}
+
+#[derive(knuffel::Decode, Debug)]
+pub struct CertificateRequest {
+    #[knuffel(argument)]
+    pub name: String,
+
+    #[knuffel(child, unwrap(argument))]
+    pub subject_entity: String,
+    #[knuffel(child, unwrap(argument))]
+    pub subject_key: String,
+    #[knuffel(child, unwrap(argument))]
+    pub digest_algorithm: Option<DigestAlgorithm>,
 }
 
 #[derive(knuffel::DecodeScalar, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ enum OutputFileExistsBehavior {
     Overwrite,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(clap::Subcommand)]
 enum Action {
     GenerateKeyPairs(GenerateKeyPairsOpts),


### PR DESCRIPTION
PKCS#10 / RFC 2986 certificate signing requests (CSR) are made up of:
- a version number
- an x501 distinguished name (the subject)
- a subject public key info (SKPI) structure
- an optional collection of attributes

CSRs are a subset of the x509 certificate structure we already generate and so this commit draws heavily from the existing code. Some refactoring was required to prevent duplication of the code that loads the required keys and config entities. The reset of this commit is a pretty mechanical conversion of config entries from the KDL file, to the rust types from spki & x509-cert crates.