### PR TITLE
Accept common policy OIDs as children of CertificatePoliciesExtension.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use miette::{IntoDiagnostic, Result};
 use sha1::Sha1;
 use x509_cert::{
     attr::AttributeTypeAndValue,
-    ext::pkix::{BasicConstraints, KeyUsage},
+    ext::pkix::{certpolicy::PolicyInformation, BasicConstraints, KeyUsage},
     name::{Name, RdnSequence, RelativeDistinguishedName},
     Certificate, TbsCertificate,
 };
@@ -487,11 +487,8 @@ impl CertificatePoliciesExtension {
     pub fn from_config(config: &config::CertificatePoliciesExtension) -> Result<Self> {
         let mut policies = Vec::new();
 
-        for oid in config.oids.iter() {
-            policies.push(x509_cert::ext::pkix::certpolicy::PolicyInformation {
-                policy_identifier: ObjectIdentifier::new(oid).into_diagnostic()?,
-                policy_qualifiers: None,
-            });
+        for policy in &config.policies {
+            policies.push(PolicyInformation::try_from(policy)?);
         }
 
         let der = x509_cert::ext::pkix::CertificatePolicies(policies)


### PR DESCRIPTION
This commit is mostly cosmetic but results in configs that are significantly more readable. We currently require configs to specify their collection of certificate policies as OID strings:

```kdl
certificate-policies {
    oid "2.23.133.5.4.100.6"
    oid "2.23.133.5.4.100.8"
    oid "2.23.133.5.4.100.12"
    oid "1.3.6.1.4.1.57551.1.3"
}
```

This is sufficient to create a certificate with the right policy extension, but it's a bit cryptic. This commit maps known / relevant OIDs to an enum with variants named as closely as possible to the names used in their respective specifications. This change allows us to replace the above kdl node with:

```kdl
certificate-policies {
    tcg-dice-kp-identity-init
    tcg-dice-kp-attest-init
    tcg-dice-kp-eca
    oana-platform-identity
}
```

The existing raw OID form remains unchanged.

NOTE: The node names used for cert policies e.g.
`tcg-dice-kp-identity-init` is the closest the `knuffel` `Decode` macro will allow us to supporting the mixed kebab and camel-case convention common to RFCs and the TCG specs e.g. `tcg-dice-kp-identityInit` This limitation is documented here:
https://docs.rs/knuffel/latest/knuffel/derive.Decode.html#enums