### PR TITLE
Remove dependency on `der` crate, use types reexported by x509-cert.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,6 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "const-oid",
- "der",
  "digest",
  "ed25519-dalek",
  "flagset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "MPL-2.0"
 [dependencies]
 clap = { version = "4.4.18", features = ["derive"] }
 const-oid = { version = "0.9.6", features = ["db"] }
-der = "0.7.8"
 digest = "0.10.7"
 ed25519-dalek = { version = "2.1.0", features = ["pem", "rand_core", "std", "zeroize"] }
 flagset = "0.4.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,16 +3,16 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use const_oid::{AssociatedOid, ObjectIdentifier};
-use der::{
-    asn1::{SetOfVec, Utf8StringRef},
-    Decode as _, Encode as _,
-};
 use digest::Digest;
 use flagset::FlagSet;
 use miette::{IntoDiagnostic, Result};
 use sha1::Sha1;
 use x509_cert::{
     attr::AttributeTypeAndValue,
+    der::{
+        asn1::{SetOfVec, Utf8StringRef},
+        Decode as _, Encode as _,
+    },
     ext::pkix::{certpolicy::PolicyInformation, BasicConstraints, KeyUsage},
     name::{Name, RdnSequence, RelativeDistinguishedName},
     Certificate, TbsCertificate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use clap::{Parser, ValueEnum};
-use der::{
-    asn1::{GeneralizedTime, UtcTime},
-    DateTime, Decode, Encode,
-};
 use miette::{Context, IntoDiagnostic, Result};
 use pki_playground::{config, Entity, Extension, KeyPair};
 use spki::SubjectPublicKeyInfo;
@@ -18,7 +14,10 @@ use std::str::FromStr;
 use std::time::SystemTime;
 use x509_cert::{
     attr::Attributes,
-    der::asn1::BitString,
+    der::{
+        asn1::{BitString, GeneralizedTime, UtcTime},
+        DateTime, Decode, Encode,
+    },
     request::{CertReq, CertReqInfo},
     time::Validity,
     Certificate, TbsCertificate,


### PR DESCRIPTION
AFAIK using the stuff from `der` when handling types from `x509-cert` causes problems if their versions get out of sync. This is why `x509-cert` reexports them.

This resolves #94 