### PR TITLE
Encode certs & CSRs as PEM.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "knuffel",
  "miette",
  "p384",
+ "pem-rfc7468",
  "pkcs8",
  "rand",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4.3"
 knuffel = "3.2.0"
 miette = { version = "5.10.0", features = ["fancy"] }
 p384 = "0.13.0"
+pem-rfc7468 = "0.7"
 pkcs8 = { version = "0.10.2", features = ["pem"] }
 rand = "0.8.5"
 rsa = { version = "0.9.6", features = ["sha2"] }


### PR DESCRIPTION
PEM should be the default anywhere it's possible.

This resolves #93.