### PR TITLE
Use long names for RDN OIDs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl<'a> TryFrom<&'a config::Entity> for Entity {
         for base_dn_attr in &value.base_dn {
             let atv = match base_dn_attr {
                 config::EntityNameComponent::CountryName(x) => AttributeTypeAndValue {
-                    oid: const_oid::db::rfc4519::C,
+                    oid: const_oid::db::rfc4519::COUNTRY_NAME,
                     value: x509_cert::der::Any::from(PrintableStringRef::new(x).into_diagnostic()?),
                 },
                 config::EntityNameComponent::StateOrProvinceName(x) => AttributeTypeAndValue {
@@ -109,15 +109,15 @@ impl<'a> TryFrom<&'a config::Entity> for Entity {
                     value: x509_cert::der::Any::from(Utf8StringRef::new(x).into_diagnostic()?),
                 },
                 config::EntityNameComponent::LocalityName(x) => AttributeTypeAndValue {
-                    oid: const_oid::db::rfc4519::L,
+                    oid: const_oid::db::rfc4519::LOCALITY_NAME,
                     value: x509_cert::der::Any::from(Utf8StringRef::new(x).into_diagnostic()?),
                 },
                 config::EntityNameComponent::OrganizationalUnitName(x) => AttributeTypeAndValue {
-                    oid: const_oid::db::rfc4519::OU,
+                    oid: const_oid::db::rfc4519::ORGANIZATIONAL_UNIT_NAME,
                     value: x509_cert::der::Any::from(Utf8StringRef::new(x).into_diagnostic()?),
                 },
                 config::EntityNameComponent::OrganizationName(x) => AttributeTypeAndValue {
-                    oid: const_oid::db::rfc4519::O,
+                    oid: const_oid::db::rfc4519::ORGANIZATION_NAME,
                     value: x509_cert::der::Any::from(Utf8StringRef::new(x).into_diagnostic()?),
                 },
             };
@@ -126,7 +126,7 @@ impl<'a> TryFrom<&'a config::Entity> for Entity {
         }
 
         rdns.push([AttributeTypeAndValue {
-            oid: const_oid::db::rfc4519::CN,
+            oid: const_oid::db::rfc4519::COMMON_NAME,
             value: x509_cert::der::Any::from(
                 Utf8StringRef::new(&value.common_name).into_diagnostic()?,
             ),


### PR DESCRIPTION
`ST` doesn't have a long name in either RFC 2256 or 4519. The `const-oid` crate defines the same oid as
`const_oid::rfc2256::STATE_OR_PROVINCE_NAME` though I can't find any reference to this string in 2256. I've opted to stick w/ the const-oids from 4519 including `ST`.