### PR TITLE
Add support for the DiceTcbInfo x509 extension.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "const-oid",
+ "der",
  "digest",
  "ed25519-dalek",
  "flagset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MPL-2.0"
 [dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
 const-oid = { version = "0.9.6", features = ["db"] }
+der = { version = "0.7.9", features = ["std"] }
 digest = "0.10.7"
 ed25519-dalek = { version = "2.1.1", features = ["pem", "rand_core", "std", "zeroize"] }
 flagset = "0.4.6"

--- a/examples/dice-tcb-info/config.kdl
+++ b/examples/dice-tcb-info/config.kdl
@@ -1,0 +1,111 @@
+key-pair "root" {
+    ed25519
+}
+
+entity "root" {
+    country-name "US"
+    organization-name "foo"
+    common-name "root"
+}
+
+certificate "root" {
+    issuer-entity "root"
+    issuer-key "root"
+
+    subject-entity "root"
+    subject-key "root"
+
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "00"
+
+    extensions {
+        basic-constraints critical=true ca=true
+        subject-key-identifier critical=false
+
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+
+        certificate-policies critical=true {
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "device-id" {
+    ed25519
+}
+
+entity "device-id" {
+    country-name "US"
+    organization-name "foo"
+    common-name "device-id"
+}
+
+certificate "device-id" {
+    issuer-certificate "root"
+    issuer-key "root"
+
+    subject-entity "device-id"
+    subject-key "device-id"
+
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "00"
+
+    extensions {
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+        }
+        certificate-policies critical=true {
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "alias" {
+    ed25519
+}
+
+entity "alias" {
+    country-name "US"
+    organization-name "foo"
+    common-name "alias"
+}
+
+certificate "alias" {
+    issuer-certificate "device-id"
+    issuer-key "device-id"
+
+    subject-entity "alias"
+    subject-key "alias"
+
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "00"
+
+    extensions {
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            digital-signature
+        }
+        certificate-policies critical=true {
+            tcg-dice-kp-attest-init
+        }
+        dice-tcb-info critical=true {
+            fwid-list {
+                fwid {
+                    digest-algorithm "sha-256"
+                    digest "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                }
+                fwid {
+                    digest-algorithm "sha-384"
+                    digest "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                }
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,7 @@ pub enum X509Extensions {
     AuthorityKeyIdentifier(AuthorityKeyIdentifierExtension),
     ExtendedKeyUsage(ExtendedKeyUsageExtension),
     CertificatePolicies(CertificatePoliciesExtension),
+    DiceTcbInfo(DiceTcbInfoExtension),
 }
 
 #[derive(knuffel::Decode, Debug)]
@@ -253,6 +254,24 @@ pub enum CertificatePolicy {
     OanaRotCodeSigningRelease,
     /// `oid` node taking an OID string argument
     Oid(#[knuffel(argument)] String),
+}
+
+#[derive(knuffel::Decode, Debug)]
+pub struct DiceTcbInfoExtension {
+    #[knuffel(property)]
+    pub critical: bool,
+
+    #[knuffel(child, unwrap(children(name = "fwid")))]
+    pub fwid_list: Vec<Fwid>,
+}
+
+#[derive(knuffel::Decode, Debug)]
+pub struct Fwid {
+    #[knuffel(child, unwrap(argument))]
+    pub digest_algorithm: DigestAlgorithm,
+
+    #[knuffel(child, unwrap(argument))]
+    pub digest: String,
 }
 
 impl TryFrom<&CertificatePolicy> for PolicyInformation {


### PR DESCRIPTION
This extension is defined in the TCG Dice Attestation Architecture spec v1.0.0 in §6.1.1. We only support the `fwids` data field from the DiceTcbInfo extension. Additional fields may be implemented as needed.

The TCG spec states that certs with the DiceTcbInfo extension MUST include the RFC 5288 AuthorityKeyIdentifier. We do not enforce this restriction but our implementation does not preclude the generation of a conformant cert chain from the KDL.