### PR TITLE
Validation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -425,5 +425,33 @@ pub fn load_and_validate(path: &std::path::Path) -> Result<Document> {
         }
     }
 
+    let mut csr_names: HashSet<&str> = HashSet::new();
+    for csr in &doc.certificate_requests {
+        if !csr_names.insert(&csr.name) {
+            miette::bail!(
+                "certificate requests must have unique names. \"{}\" is used more than once.",
+                csr.name
+            )
+        }
+    }
+
+    for csr in &doc.certificate_requests {
+        if !entity_names.contains(csr.subject_entity.as_str()) {
+            miette::bail!(
+                "certificate request \"{}\" subject entity \"{}\" does not exist",
+                csr.name,
+                csr.subject_key
+            )
+        }
+
+        if !kp_names.contains(csr.subject_key.as_str()) {
+            miette::bail!(
+                "certificate request \"{}\" subject key pair \"{}\" does not exist",
+                csr.name,
+                csr.subject_key
+            )
+        }
+    }
+
     Ok(doc)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,11 @@ fn main() -> Result<()> {
             let entities = load_entities(&doc.entities)?;
 
             for cert_config in &doc.certificates {
-                let subject_entity = entities.get(&cert_config.subject_entity).unwrap();
+                let subject_entity = entities.get(&cert_config.subject_entity).ok_or(miette!(
+                    "Subject entity for certificate {} does not exist: {}",
+                    &cert_config.name,
+                    &cert_config.subject_entity,
+                ))?;
                 let subject_kp = key_pairs.get(&cert_config.subject_key).unwrap();
 
                 let issuer_cert_pem =

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,11 @@ fn main() -> Result<()> {
                     &cert_config.name,
                     &cert_config.subject_entity,
                 ))?;
-                let subject_kp = key_pairs.get(&cert_config.subject_key).unwrap();
+                let subject_kp = key_pairs.get(&cert_config.subject_key).ok_or(miette!(
+                    "Subject key pair for certificate {} does not exist: {}",
+                    &cert_config.name,
+                    &cert_config.subject_key,
+                ))?;
 
                 let issuer_cert_pem =
                     if let Some(issuer_cert_name) = &cert_config.issuer_certificate {

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,10 @@ fn main() -> Result<()> {
                         .clone()
                 };
 
-                let issuer_kp = key_pairs.get(&cert_config.issuer_key).unwrap();
+                let issuer_kp = key_pairs.get(&cert_config.issuer_key).ok_or(miette!(
+                    "Issuer key does not exist: {}",
+                    &cert_config.issuer_key
+                ))?;
 
                 let not_after = DateTime::from_str(&cert_config.not_after).into_diagnostic()?;
                 let not_after = if not_after.year() >= 2050 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use clap::{Parser, ValueEnum};
-use miette::{Context, IntoDiagnostic, Result};
+use miette::{miette, Context, IntoDiagnostic, Result};
 use pem_rfc7468::LineEnding;
 use pki_playground::{config, Entity, Extension, KeyPair};
 use spki::SubjectPublicKeyInfo;
@@ -162,7 +162,10 @@ fn main() -> Result<()> {
             let entities = load_entities(&doc.entities)?;
 
             for csr_config in &doc.certificate_requests {
-                let subject_kp = key_pairs.get(&csr_config.subject_key).unwrap();
+                let subject_kp = key_pairs.get(&csr_config.subject_key).ok_or(miette!(
+                    "Subject key does not exist: {}",
+                    &csr_config.subject_key
+                ))?;
                 let public_key = SubjectPublicKeyInfo::from_der(subject_kp.to_spki()?.as_bytes())
                     .into_diagnostic()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,10 @@ fn main() -> Result<()> {
                 let public_key = SubjectPublicKeyInfo::from_der(subject_kp.to_spki()?.as_bytes())
                     .into_diagnostic()?;
 
-                let subject = entities.get(&csr_config.subject_entity).unwrap();
+                let subject = entities.get(&csr_config.subject_entity).ok_or(miette!(
+                    "Entity does not exist: {}",
+                    &csr_config.subject_entity
+                ))?;
                 let subject = subject.distinguished_name().clone();
 
                 let info = CertReqInfo {


### PR DESCRIPTION
The `load_and_validate` function performs consistency checks over the parsed data. I missed this when adding CSR support. The code that later handles this data assumes that the data is consistent and will panic if it isn't. This PR adds the consistency check for CSRs as well as appropriate error handling when searching for keys, entities etc in the event that the validation code is missing something in the future.