### PR TITLE
Webpki extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +739,7 @@ dependencies = [
  "ed25519-dalek",
  "flagset",
  "hex",
+ "ipnet",
  "knuffel",
  "miette",
  "p384",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ digest = "0.10.7"
 ed25519-dalek = { version = "2.1.1", features = ["pem", "rand_core", "std", "zeroize"] }
 flagset = "0.4.6"
 hex = "0.4.3"
+ipnet = "2.11.0"
 knuffel = "3.2.0"
 miette = { version = "5.10.0", features = ["fancy"] }
 p384 = "0.13.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,7 @@ pub enum X509Extensions {
     CertificatePolicies(CertificatePoliciesExtension),
     DiceTcbInfo(DiceTcbInfoExtension),
     SubjectAltName(SubjectAltNameExtension),
+    NameConstraints(NameConstraintsExtension),
 }
 
 #[derive(knuffel::Decode, Debug)]
@@ -346,6 +347,18 @@ pub struct SubjectAltNameExtension {
 
     #[knuffel(children)]
     pub names: Vec<GeneralName>,
+}
+
+#[derive(knuffel::Decode, Debug)]
+pub struct NameConstraintsExtension {
+    #[knuffel(property)]
+    pub critical: bool,
+
+    #[knuffel(child, unwrap(children))]
+    pub permitted: Option<Vec<GeneralName>>,
+
+    #[knuffel(child, unwrap(children))]
+    pub excluded: Option<Vec<GeneralName>>,
 }
 
 pub fn load_and_validate(path: &std::path::Path) -> Result<Document> {


### PR DESCRIPTION
This is initial work on #11 & is useful for testing. Probably won't be useful for much else w/o support for domain names. This was tested w/ a simple rustls client / server.

Add a `NameConstraints` extension to a certificate with a fragment like the following:

```kdl
name-constraints critical=false {
    permitted {
        ip-addr "127.0.0.1/24"
    }
}
```

Add a `SubjectAltName` extension to a certificate with a fragment like the following:

```kdl
subject-alt-name critical=false {
    ip-addr "127.0.0.1"
}
```