### PR TITLE
Add KDL node for `CertificateList`s & command to generate them

### DIFF
--- a/examples/simple-chain-client-server_ed25519/config.kdl
+++ b/examples/simple-chain-client-server_ed25519/config.kdl
@@ -175,6 +175,9 @@ certificate "TEST USE ONLY - Test Server A" {
     serial-number "01"
 }
 
+certificate-list "TEST USE ONLY - Test Server A" \
+    "TEST USE ONLY - Test Server A" \
+    "TEST USE ONLY - Test Int A"
 
 certificate "TEST USE ONLY - Test Client A" {
     subject-entity "TEST USE ONLY - Test Client A"

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,9 @@ pub struct Document {
 
     #[knuffel(children(name = "certificate-request"))]
     pub certificate_requests: Vec<CertificateRequest>,
+
+    #[knuffel(children(name = "certificate-list"))]
+    pub certificate_lists: Vec<CertificateList>,
 }
 
 #[derive(knuffel::Decode, Debug)]
@@ -107,6 +110,15 @@ pub struct CertificateRequest {
     pub subject_key: String,
     #[knuffel(child, unwrap(argument))]
     pub digest_algorithm: Option<DigestAlgorithm>,
+}
+
+#[derive(knuffel::Decode, Debug)]
+pub struct CertificateList {
+    #[knuffel(argument)]
+    pub name: String,
+
+    #[knuffel(arguments)]
+    pub certificates: Vec<String>,
 }
 
 #[derive(knuffel::DecodeScalar, Debug)]
@@ -478,6 +490,14 @@ pub fn load_and_validate(path: &std::path::Path) -> Result<Document> {
                 csr.name,
                 csr.subject_key
             )
+        }
+    }
+
+    for certlist in &doc.certificate_lists {
+        for cert in &certlist.certificates {
+            if !cert_names.contains(cert.as_str()) {
+                miette::bail!("certificate \"{}\" does not exist", cert,)
+            }
         }
     }
 


### PR DESCRIPTION
It's common for ordered lists of certificates to be concatenated and stored or transferred as a single file / unit. Different applications / protocols may expect a particular ordering. To support as many use-cases as possible we do not enforce any particular ordering or relationship between the certificates in a certificate list. We simply concatenate them in the order specified.

So far we only encode files as PEM and so we use the file extension `.certlist.pem`.

A `CertificateList` is defined in the KDL as:
```kdl
certificate-list "name" \
    "cert-name-1" \
    "cert-name-2"
```
The output file name prefix is taken from the first attribute of the KDL ("name" in this example). The remaining attributes are the string names assigned `certificate` nodes defined elsewhere in the document.