### PR TITLE
Add library support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "camino"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +305,12 @@ dependencies = [
  "quote",
  "syn 2.0.99",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -732,6 +747,7 @@ dependencies = [
 name = "pki-playground"
 version = "0.2.0"
 dependencies = [
+ "camino",
  "clap",
  "const-oid",
  "der",
@@ -745,6 +761,7 @@ dependencies = [
  "p384",
  "pem-rfc7468",
  "pkcs8",
+ "pretty_assertions",
  "rand",
  "rsa",
  "sha1",
@@ -763,6 +780,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -914,18 +941,27 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1280,6 +1316,12 @@ dependencies = [
  "spki",
  "tls_codec",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+camino = { version = "1.2.0", features = ["serde1"] }
 clap = { version = "4.5.31", features = ["derive"] }
 const-oid = { version = "0.9.6", features = ["db"] }
 der = { version = "0.7.9", features = ["std"] }
@@ -29,3 +30,6 @@ signature = "2.2.0"
 spki = "0.7.3"
 x509-cert = "0.2.5"
 zeroize = "1.8.1"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1" 

--- a/examples/sprockets/config.kdl
+++ b/examples/sprockets/config.kdl
@@ -1,0 +1,429 @@
+key-pair "test-root-a" {
+    p384
+}
+
+entity "test-root-a" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "test-root-a"
+}
+
+certificate "test-root-a" {
+    issuer-entity "test-root-a"
+    issuer-key "test-root-a"
+
+    subject-entity "test-root-a"
+    subject-key "test-root-a"
+
+    digest-algorithm "sha-384"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "00"
+
+    extensions {
+        subject-key-identifier critical=false
+
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "test-signer-a1" {
+    p384
+}
+
+entity "test-signer-a1" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "test-signer-a1"
+}
+
+certificate "test-signer-a1" {
+    issuer-certificate "test-root-a"
+    issuer-key "test-root-a"
+
+    subject-entity "test-signer-a1"
+    subject-key "test-signer-a1"
+
+    digest-algorithm "sha-384"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "01"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+/// Device 1
+key-pair "test-platformid-1" {
+    ed25519
+}
+
+entity "test-platformid-1" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "PDV2:PPP-PPPPPPP:RRR:1"
+}
+
+certificate "test-platformid-1" {
+    issuer-certificate "test-signer-a1"
+    issuer-key "test-signer-a1"
+
+    subject-entity "test-platformid-1"
+    subject-key "test-platformid-1"
+
+    digest-algorithm "sha-384"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "1001"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "test-deviceid-1" {
+    ed25519
+}
+
+entity "test-deviceid-1" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "test-deviceid-1"
+}
+
+certificate "test-deviceid-1" {
+    issuer-certificate "test-platformid-1"
+    issuer-key "test-platformid-1"
+
+    subject-entity "test-deviceid-1"
+    subject-key "test-deviceid-1"
+
+    digest-algorithm "sha-512"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "2001"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "test-sprockets-auth-1" {
+    ed25519
+}
+
+entity "test-sprockets-auth-1" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "test-sprockets-auth-1"
+}
+
+certificate "test-sprockets-auth-1" {
+    issuer-certificate "test-deviceid-1"
+    issuer-key "test-deviceid-1"
+
+    subject-entity "test-sprockets-auth-1"
+    subject-key "test-sprockets-auth-1"
+
+    digest-algorithm "sha-512"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "3001"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=false
+        key-usage critical=true {
+            digital-signature
+            non-repudiation
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+certificate-list "test-sprockets-auth-1" \
+    "test-sprockets-auth-1" \
+    "test-deviceid-1" \
+    "test-platformid-1" \
+    "test-signer-a1"
+
+key-pair "test-alias-1" {
+    ed25519
+}
+
+entity "test-alias-1" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "alias"
+}
+
+certificate "test-alias-1" {
+    issuer-certificate "test-deviceid-1"
+    issuer-key "test-deviceid-1"
+
+    subject-entity "test-alias-1"
+    subject-key "test-alias-1"
+
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "00"
+
+    extensions {
+        basic-constraints critical=true ca=false
+        key-usage critical=true {
+            digital-signature
+        }
+        certificate-policies critical=true {
+            tcg-dice-kp-attest-init
+        }
+        dice-tcb-info critical=true {
+            fwid-list {
+                fwid {
+                    digest-algorithm "sha3-256"
+                    digest "72fa8f8ea84a42251031366002cbb36281d0131f78cd680436116a720cdd9de5"
+                }
+            }
+        }
+    }
+}
+
+certificate-list "test-alias-1" \
+    "test-alias-1" \
+    "test-deviceid-1" \
+    "test-platformid-1" \
+    "test-signer-a1"
+
+/// Device 2
+
+key-pair "test-platformid-2" {
+    ed25519
+}
+
+entity "test-platformid-2" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "PDV2:PPP-PPPPPPP:RRR:2"
+}
+
+certificate "test-platformid-2" {
+    issuer-certificate "test-signer-a1"
+    issuer-key "test-signer-a1"
+
+    subject-entity "test-platformid-2"
+    subject-key "test-platformid-2"
+
+    digest-algorithm "sha-384"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "1002"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "test-deviceid-2" {
+    ed25519
+}
+
+entity "test-deviceid-2" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "test-deviceid-2"
+}
+
+certificate "test-deviceid-2" {
+    issuer-certificate "test-platformid-2"
+    issuer-key "test-platformid-2"
+
+    subject-entity "test-deviceid-2"
+    subject-key "test-deviceid-2"
+
+    digest-algorithm "sha-512"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "2002"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=true
+        key-usage critical=true {
+            key-cert-sign
+            crl-sign
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+key-pair "test-sprockets-auth-2" {
+    ed25519
+}
+
+entity "test-sprockets-auth-2" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "test-sprockets-auth-2"
+}
+
+certificate "test-sprockets-auth-2" {
+    issuer-certificate "test-deviceid-2"
+    issuer-key "test-deviceid-2"
+
+    subject-entity "test-sprockets-auth-2"
+    subject-key "test-sprockets-auth-2"
+
+    digest-algorithm "sha-512"
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "3002"
+
+    extensions {
+        subject-key-identifier critical=false
+        authority-key-identifier critical=false {
+            key-id
+        }
+
+        basic-constraints critical=true ca=false
+        key-usage critical=true {
+            digital-signature
+            non-repudiation
+        }
+        certificate-policies critical=true {
+            oana-platform-identity
+            tcg-dice-kp-identity-init
+            tcg-dice-kp-attest-init
+            tcg-dice-kp-eca
+        }
+    }
+}
+
+certificate-list "test-sprockets-auth-2" \
+    "test-sprockets-auth-2" \
+    "test-deviceid-2" \
+    "test-platformid-2" \
+    "test-signer-a1"
+
+key-pair "test-alias-2" {
+    ed25519
+}
+
+entity "test-alias-2" {
+    country-name "US"
+    organization-name "Oxide Computer Company"
+    common-name "alias"
+}
+
+certificate "test-alias-2" {
+    issuer-certificate "test-deviceid-2"
+    issuer-key "test-deviceid-2"
+
+    subject-entity "test-alias-2"
+    subject-key "test-alias-2"
+
+    not-after "9999-12-31T23:59:59Z"
+    serial-number "00"
+
+    extensions {
+        basic-constraints critical=true ca=false
+        key-usage critical=true {
+            digital-signature
+        }
+        certificate-policies critical=true {
+            tcg-dice-kp-attest-init
+        }
+        dice-tcb-info critical=true {
+            fwid-list {
+                fwid {
+                    digest-algorithm "sha3-256"
+                    digest "72fa8f8ea84a42251031366002cbb36281d0131f78cd680436116a720cdd9de5"
+                }
+            }
+        }
+    }
+}
+
+certificate-list "test-alias-2" \
+    "test-alias-2" \
+    "test-deviceid-2" \
+    "test-platformid-2" \
+    "test-signer-a1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::HashSet;
-
+use camino::Utf8Path;
 use miette::{IntoDiagnostic, Result};
 use x509_cert::{ext::pkix::certpolicy::PolicyInformation, spki::ObjectIdentifier};
+
+use crate::ValidDocument;
 
 #[derive(knuffel::Decode, Debug)]
 pub struct Document {
@@ -25,7 +26,7 @@ pub struct Document {
     pub certificate_lists: Vec<CertificateList>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct KeyPair {
     #[knuffel(argument)]
     pub name: String,
@@ -33,14 +34,14 @@ pub struct KeyPair {
     pub key_type: Vec<KeyType>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub enum KeyType {
     Rsa(RsaKeyConfig),
     P384,
     Ed25519,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct RsaKeyConfig {
     #[knuffel(property, default = 2048)]
     pub num_bits: usize,
@@ -48,7 +49,7 @@ pub struct RsaKeyConfig {
     pub public_exponent: usize,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, Clone, PartialEq, Eq)]
 pub struct Entity {
     #[knuffel(argument)]
     pub name: String,
@@ -58,7 +59,7 @@ pub struct Entity {
     pub base_dn: Vec<EntityNameComponent>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, Clone, PartialEq, Eq)]
 pub enum EntityNameComponent {
     CountryName(#[knuffel(argument)] String),
     StateOrProvinceName(#[knuffel(argument)] String),
@@ -67,7 +68,7 @@ pub enum EntityNameComponent {
     OrganizationalUnitName(#[knuffel(argument)] String),
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct Certificate {
     #[knuffel(argument)]
     pub name: String,
@@ -99,7 +100,7 @@ pub struct Certificate {
     pub extensions: Option<Vec<X509Extensions>>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct CertificateRequest {
     #[knuffel(argument)]
     pub name: String,
@@ -112,7 +113,7 @@ pub struct CertificateRequest {
     pub digest_algorithm: Option<DigestAlgorithm>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct CertificateList {
     #[knuffel(argument)]
     pub name: String,
@@ -121,7 +122,7 @@ pub struct CertificateList {
     pub certificates: Vec<String>,
 }
 
-#[derive(knuffel::DecodeScalar, Debug)]
+#[derive(knuffel::DecodeScalar, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 pub enum DigestAlgorithm {
     Sha_256,
@@ -132,7 +133,7 @@ pub enum DigestAlgorithm {
     Sha3_512,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub enum X509Extensions {
     BasicConstraints(BasicConstraintsExtension),
     KeyUsage(KeyUsageExtension),
@@ -145,7 +146,7 @@ pub enum X509Extensions {
     NameConstraints(NameConstraintsExtension),
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct BasicConstraintsExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -157,7 +158,7 @@ pub struct BasicConstraintsExtension {
     pub path_len: Option<u8>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct KeyUsageExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -190,7 +191,7 @@ pub struct KeyUsageExtension {
     pub decipher_only: bool,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct ExtendedKeyUsageExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -217,13 +218,13 @@ pub struct ExtendedKeyUsageExtension {
     pub oids: Vec<String>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct SubjectKeyIdentifierExtension {
     #[knuffel(property)]
     pub critical: bool,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct AuthorityKeyIdentifierExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -237,7 +238,7 @@ pub struct AuthorityKeyIdentifierExtension {
 
 /// The `CertificatePolicy` enum represents the set of KDL nodes that `pki-playground` can map to
 /// OIDs. Configs may also provide OIDs in their string forms using the `oid` node.
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub enum CertificatePolicy {
     /// Initial attestation policy OID from [DICE Certificate
     /// Profiles](https://trustedcomputinggroup.org/resource/dice-certificate-profiles/) §5.1.5.3
@@ -273,7 +274,7 @@ pub enum CertificatePolicy {
     Oid(#[knuffel(argument)] String),
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct DiceTcbInfoExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -282,7 +283,7 @@ pub struct DiceTcbInfoExtension {
     pub fwid_list: Vec<Fwid>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct Fwid {
     #[knuffel(child, unwrap(argument))]
     pub digest_algorithm: DigestAlgorithm,
@@ -338,7 +339,7 @@ impl TryFrom<&CertificatePolicy> for PolicyInformation {
     }
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct CertificatePoliciesExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -347,12 +348,12 @@ pub struct CertificatePoliciesExtension {
     pub policies: Vec<CertificatePolicy>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub enum GeneralName {
     IpAddr(#[knuffel(argument)] String),
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct SubjectAltNameExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -361,7 +362,7 @@ pub struct SubjectAltNameExtension {
     pub names: Vec<GeneralName>,
 }
 
-#[derive(knuffel::Decode, Debug)]
+#[derive(knuffel::Decode, Debug, PartialEq, Eq)]
 pub struct NameConstraintsExtension {
     #[knuffel(property)]
     pub critical: bool,
@@ -373,133 +374,8 @@ pub struct NameConstraintsExtension {
     pub excluded: Option<Vec<GeneralName>>,
 }
 
-pub fn load_and_validate(path: &std::path::Path) -> Result<Document> {
+pub fn load_and_validate(path: &Utf8Path) -> Result<ValidDocument> {
     let in_kdl = std::fs::read_to_string(path).into_diagnostic()?;
-    let doc: Document = knuffel::parse(&path.to_string_lossy(), &in_kdl)?;
-
-    let mut kp_names: HashSet<&str> = HashSet::new();
-    for kp in &doc.key_pairs {
-        if kp.key_type.len() != 1 {
-            miette::bail!(
-                "key pairs must have exactly one key type. key pair \"{}\" has {}.",
-                kp.name,
-                kp.key_type.len()
-            );
-        }
-        if !kp_names.insert(&kp.name) {
-            miette::bail!(
-                "key pairs must have unique names. \"{}\" is used more than once.",
-                kp.name
-            )
-        }
-    }
-
-    let mut entity_names: HashSet<&str> = HashSet::new();
-    for entity in &doc.entities {
-        if !entity_names.insert(&entity.name) {
-            miette::bail!(
-                "entities must have unique names. \"{}\" is used more than once.",
-                entity.name
-            )
-        }
-    }
-
-    // Certificates can name other certificates as their issuer so need to
-    // gather all the names before checking validity.
-    let mut cert_names: HashSet<&str> = HashSet::new();
-    for cert in &doc.certificates {
-        if !cert_names.insert(&cert.name) {
-            miette::bail!(
-                "certificates must have unique names. \"{}\" is used more than once.",
-                cert.name
-            )
-        }
-    }
-
-    for cert in &doc.certificates {
-        if !entity_names.contains(cert.subject_entity.as_str()) {
-            miette::bail!(
-                "certificate \"{}\" subject entity \"{}\" does not exist",
-                cert.name,
-                cert.subject_key
-            )
-        }
-
-        if !kp_names.contains(cert.subject_key.as_str()) {
-            miette::bail!(
-                "certificate \"{}\" subject key pair \"{}\" does not exist",
-                cert.name,
-                cert.subject_key
-            )
-        }
-
-        match (&cert.issuer_entity, &cert.issuer_certificate) {
-            (None, None) => miette::bail!("certificate \"{}\" must specify either an issuer entity or certificate", cert.name),
-            (Some(_), Some(_)) => miette::bail!("certificate \"{}\" specifies both an issuer entity and certificate.  Only one may be specified.", cert.name),
-            (Some(entity), None) => {
-                if !entity_names.contains(entity.as_str()) {
-                    miette::bail!(
-                        "certificate \"{}\" issuer entity \"{}\" does not exist",
-                        cert.name,
-                        cert.issuer_key
-                    )
-                }
-            }
-            (None, Some(cert_name)) => {
-                if !cert_names.contains(cert_name.as_str()) {
-                    miette::bail!(
-                        "certificate \"{}\" issuer certificate \"{}\" does not exist",
-                        cert.name,
-                        cert.issuer_key
-                    )
-                }
-            }
-        }
-
-        if !kp_names.contains(cert.issuer_key.as_str()) {
-            miette::bail!(
-                "certificate \"{}\" issuer key pair \"{}\" does not exist",
-                cert.name,
-                cert.issuer_key
-            )
-        }
-    }
-
-    let mut csr_names: HashSet<&str> = HashSet::new();
-    for csr in &doc.certificate_requests {
-        if !csr_names.insert(&csr.name) {
-            miette::bail!(
-                "certificate requests must have unique names. \"{}\" is used more than once.",
-                csr.name
-            )
-        }
-    }
-
-    for csr in &doc.certificate_requests {
-        if !entity_names.contains(csr.subject_entity.as_str()) {
-            miette::bail!(
-                "certificate request \"{}\" subject entity \"{}\" does not exist",
-                csr.name,
-                csr.subject_key
-            )
-        }
-
-        if !kp_names.contains(csr.subject_key.as_str()) {
-            miette::bail!(
-                "certificate request \"{}\" subject key pair \"{}\" does not exist",
-                csr.name,
-                csr.subject_key
-            )
-        }
-    }
-
-    for certlist in &doc.certificate_lists {
-        for cert in &certlist.certificates {
-            if !cert_names.contains(cert.as_str()) {
-                miette::bail!("certificate \"{}\" does not exist", cert,)
-            }
-        }
-    }
-
-    Ok(doc)
+    let doc: Document = knuffel::parse(path.as_str(), &in_kdl)?;
+    ValidDocument::validate(doc)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,15 @@ pub mod config;
 pub mod ed25519;
 pub mod p384;
 pub mod rsa;
+pub mod sprockets;
+mod valid_document;
 
 use crate::config::DigestAlgorithm;
 use crate::p384::P384KeyPair;
 use crate::rsa::RsaKeyPair;
 use ed25519::Ed25519KeyPair;
+pub use valid_document::OutputFileExistsBehavior;
+pub(crate) use valid_document::ValidDocument;
 
 pub trait KeyPair {
     fn name(&self) -> &str;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,42 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use clap::{Parser, ValueEnum};
-use miette::{miette, Context, IntoDiagnostic, Result};
-use pem_rfc7468::LineEnding;
-use pki_playground::{config, Entity, Extension, KeyPair};
-use spki::SubjectPublicKeyInfo;
-use std::collections::HashMap;
-use std::fs::OpenOptions;
-use std::io::{Read, Write};
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::time::SystemTime;
-use x509_cert::{
-    attr::Attributes,
-    der::{
-        asn1::{BitString, GeneralizedTime, UtcTime},
-        DateTime, Decode, DecodePem, Encode, EncodePem,
-    },
-    request::{CertReq, CertReqInfo},
-    time::Validity,
-    Certificate, TbsCertificate,
-};
+use camino::Utf8PathBuf;
+use clap::Parser;
+use miette::{Context, Result};
+use pki_playground::OutputFileExistsBehavior;
 
 #[derive(clap::Parser)]
 struct Options {
     #[arg(short, long, value_name = "FILE")]
-    config: Option<PathBuf>,
+    config: Option<Utf8PathBuf>,
 
     #[command(subcommand)]
     action: Action,
-}
-
-#[derive(Clone, Copy, PartialEq, ValueEnum)]
-enum OutputFileExistsBehavior {
-    Skip,
-    Error,
-    Overwrite,
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -77,88 +53,6 @@ struct GenerateCertificateListsOpts {
     output_exists: OutputFileExistsBehavior,
 }
 
-fn write_to_file(
-    filename: &str,
-    contents: &[u8],
-    exists_behavior: OutputFileExistsBehavior,
-) -> Result<()> {
-    let mut open_opts = OpenOptions::new();
-    open_opts.write(true);
-    match exists_behavior {
-        OutputFileExistsBehavior::Skip | OutputFileExistsBehavior::Error => {
-            open_opts.create_new(true)
-        }
-        OutputFileExistsBehavior::Overwrite => open_opts.create(true).truncate(true),
-    };
-
-    let mut file = match open_opts.open(filename) {
-        Err(e)
-            if e.kind() == std::io::ErrorKind::AlreadyExists
-                && exists_behavior == OutputFileExistsBehavior::Skip =>
-        {
-            println!("File \"{}\" already exists, skipping", filename);
-            return Ok(());
-        }
-        x => x
-            .into_diagnostic()
-            .wrap_err(format!("Unable to open file \"{}\" for writing", filename))?,
-    };
-    file.write_all(contents)
-        .into_diagnostic()
-        .wrap_err(format!("Unable to write to file \"{}\"", filename))
-}
-
-fn load_keypairs(
-    key_pairs_cfg: &Vec<config::KeyPair>,
-) -> Result<HashMap<String, Box<dyn KeyPair>>> {
-    let mut key_pairs = HashMap::new();
-
-    for kp_config in key_pairs_cfg {
-        let kp_filename = format!("{}.key.pem", kp_config.name);
-        let kp_pem = std::fs::read_to_string(&kp_filename)
-            .into_diagnostic()
-            .wrap_err(format!(
-                "Unable to load key pair \"{}\" from \"{}\"",
-                kp_config.name, &kp_filename
-            ))?;
-        let kp = <dyn KeyPair>::from_pem(kp_config, &kp_pem)?;
-        key_pairs.insert(String::from(kp.name()), kp);
-    }
-
-    Ok(key_pairs)
-}
-
-fn load_entities(entities: &Vec<config::Entity>) -> Result<HashMap<String, Entity>> {
-    let mut entity_map = HashMap::new();
-
-    for entity_config in entities {
-        let entity = pki_playground::Entity::try_from(entity_config)?;
-        entity_map.insert(String::from(entity.name()), entity);
-    }
-
-    Ok(entity_map)
-}
-
-fn load_certificates(
-    certificates_cfg: &Vec<config::Certificate>,
-) -> Result<HashMap<String, x509_cert::Certificate>> {
-    let mut certs = HashMap::new();
-
-    for cert_cfg in certificates_cfg {
-        let cert_filename = format!("{}.cert.pem", cert_cfg.name);
-        let cert_pem = std::fs::read_to_string(&cert_filename)
-            .into_diagnostic()
-            .wrap_err(format!(
-                "Unable to load certificate \"{}\" from \"{}\"",
-                cert_cfg.name, &cert_filename
-            ))?;
-        let cert = x509_cert::Certificate::from_pem(cert_pem).into_diagnostic()?;
-        certs.insert(cert_cfg.name.clone(), cert);
-    }
-
-    Ok(certs)
-}
-
 fn main() -> Result<()> {
     let opts = Options::parse();
 
@@ -167,247 +61,23 @@ fn main() -> Result<()> {
         None => "config.kdl".into(),
     };
 
-    let doc = pki_playground::config::load_and_validate(&config_path).wrap_err(format!(
-        "Loading config from \"{}\" failed",
-        config_path.display()
-    ))?;
+    let doc = pki_playground::config::load_and_validate(&config_path)
+        .wrap_err(format!("Loading config from \"{}\" failed", config_path))?;
+
+    let dir = ".".into();
 
     match opts.action {
         Action::GenerateCertificateLists(action_opts) => {
-            let certificates = load_certificates(&doc.certificates)?;
-            for certlist_cfg in &doc.certificate_lists {
-                let mut cert_chain = String::new();
-                let certlist_filename = format!("{}.certlist.pem", certlist_cfg.name);
-                println!("Writing pki path to \"{}\"", &certlist_filename);
-                for cert_name in &certlist_cfg.certificates {
-                    let cert = certificates.get(cert_name).ok_or(miette!(
-                        "Certificate does not exist: {}",
-                        &certlist_cfg.name
-                    ))?;
-                    cert_chain += &cert.to_pem(LineEnding::CRLF).into_diagnostic()?;
-                }
-                write_to_file(
-                    &certlist_filename,
-                    cert_chain.as_bytes(),
-                    action_opts.output_exists,
-                )?
-            }
+            doc.write_certificate_lists(dir, action_opts.output_exists)
         }
         Action::GenerateKeyPairs(action_opts) => {
-            for kp_config in &doc.key_pairs {
-                let kp = <dyn KeyPair>::new(kp_config)?;
-                let kp_filename = format!("{}.key.pem", kp_config.name);
-                println!("Writing key pair to \"{}\"", &kp_filename);
-                write_to_file(
-                    &kp_filename,
-                    kp.to_pkcs8_pem()?.as_bytes(),
-                    action_opts.output_exists,
-                )?
-            }
+            doc.write_key_pairs(dir, action_opts.output_exists)
         }
         Action::GenerateCertificateRequests(action_opts) => {
-            let key_pairs = load_keypairs(&doc.key_pairs)?;
-            let entities = load_entities(&doc.entities)?;
-
-            for csr_config in &doc.certificate_requests {
-                let subject_kp = key_pairs.get(&csr_config.subject_key).ok_or(miette!(
-                    "Subject key does not exist: {}",
-                    &csr_config.subject_key
-                ))?;
-                let public_key = SubjectPublicKeyInfo::from_der(subject_kp.to_spki()?.as_bytes())
-                    .into_diagnostic()?;
-
-                let subject = entities.get(&csr_config.subject_entity).ok_or(miette!(
-                    "Entity does not exist: {}",
-                    &csr_config.subject_entity
-                ))?;
-                let subject = subject.distinguished_name().clone();
-
-                let info = CertReqInfo {
-                    version: x509_cert::request::Version::V1,
-                    subject,
-                    public_key,
-                    attributes: Attributes::default(),
-                };
-                let info_der = info.to_der().into_diagnostic()?;
-
-                let signature = subject_kp
-                    .signature(csr_config.digest_algorithm.as_ref(), &info_der)
-                    .wrap_err("Failed to sign CSR info structure")?;
-                let signature = BitString::from_bytes(&signature).into_diagnostic()?;
-
-                let algorithm = csr_config.digest_algorithm.as_ref();
-                let algorithm = subject_kp.signature_algorithm(algorithm)?;
-
-                let csr = CertReq {
-                    info,
-                    algorithm,
-                    signature,
-                };
-
-                let csr_filename = format!("{}.csr.pem", csr_config.name);
-                println!("Writing certificate request to \"{}\"", &csr_filename);
-                write_to_file(
-                    &csr_filename,
-                    csr.to_pem(LineEnding::CRLF).into_diagnostic()?.as_bytes(),
-                    action_opts.output_exists,
-                )?
-            }
+            doc.write_certificate_requests(dir, action_opts.output_exists)
         }
         Action::GenerateCertificates(action_opts) => {
-            let key_pairs = load_keypairs(&doc.key_pairs)?;
-            let entities = load_entities(&doc.entities)?;
-
-            for cert_config in &doc.certificates {
-                let subject_entity = entities.get(&cert_config.subject_entity).ok_or(miette!(
-                    "Subject entity for certificate {} does not exist: {}",
-                    &cert_config.name,
-                    &cert_config.subject_entity,
-                ))?;
-                let subject_kp = key_pairs.get(&cert_config.subject_key).ok_or(miette!(
-                    "Subject key pair for certificate {} does not exist: {}",
-                    &cert_config.name,
-                    &cert_config.subject_key,
-                ))?;
-
-                let issuer_cert_pem =
-                    if let Some(issuer_cert_name) = &cert_config.issuer_certificate {
-                        let issuer_cert_filename = format!("{}.cert.pem", issuer_cert_name);
-                        let mut issuer_cert_pem = Vec::new();
-                        let mut issuer_cert_file = std::fs::File::open(&issuer_cert_filename)
-                            .into_diagnostic()
-                            .wrap_err(format!(
-                                "Unable to load issuer certificate \"{}\" from file \"{}\"",
-                                issuer_cert_name, issuer_cert_filename
-                            ))?;
-                        issuer_cert_file
-                            .read_to_end(&mut issuer_cert_pem)
-                            .into_diagnostic()?;
-                        Some(issuer_cert_pem)
-                    } else {
-                        None
-                    };
-
-                let issuer_cert = if let Some(issuer_cert_pem) = &issuer_cert_pem {
-                    Some(x509_cert::Certificate::from_pem(issuer_cert_pem).into_diagnostic()?)
-                } else {
-                    None
-                };
-
-                let issuer_dn = if let Some(issuer_cert) = &issuer_cert {
-                    issuer_cert.tbs_certificate.subject.clone()
-                } else {
-                    entities
-                        .get(cert_config.issuer_entity.as_ref().unwrap())
-                        .unwrap()
-                        .distinguished_name()
-                        .clone()
-                };
-
-                let issuer_kp = key_pairs.get(&cert_config.issuer_key).ok_or(miette!(
-                    "Issuer key does not exist: {}",
-                    &cert_config.issuer_key
-                ))?;
-
-                let not_after = DateTime::from_str(&cert_config.not_after).into_diagnostic()?;
-                let not_after = if not_after.year() >= 2050 {
-                    GeneralizedTime::from(not_after).into()
-                } else {
-                    UtcTime::try_from(not_after).into_diagnostic()?.into()
-                };
-                let not_before = match &cert_config.not_before {
-                    None => DateTime::from_system_time(SystemTime::now()).into_diagnostic()?,
-                    Some(x) => DateTime::from_str(x).into_diagnostic()?,
-                };
-                let not_before = if not_before.year() >= 2050 {
-                    GeneralizedTime::from(not_before).into()
-                } else {
-                    UtcTime::try_from(not_before).into_diagnostic()?.into()
-                };
-
-                let validity = Validity {
-                    not_before,
-                    not_after,
-                };
-
-                let signature_algorithm =
-                    issuer_kp.signature_algorithm(cert_config.digest_algorithm.as_ref())?;
-
-                let spki_der = subject_kp.to_spki()?;
-                let spki = SubjectPublicKeyInfo::from_der(spki_der.as_bytes()).into_diagnostic()?;
-
-                let serial_number = hex::decode(&cert_config.serial_number)
-                    .into_diagnostic()
-                    .wrap_err(format!(
-                        "Serial number of certificate \"{}\"",
-                        cert_config.name
-                    ))?;
-                if serial_number.len() > 20 {
-                    return Err(miette::miette!(
-                        "Certificate serial number must be at most 20 octets"
-                    ));
-                }
-
-                let mut tbs_cert = TbsCertificate {
-                    version: x509_cert::Version::V3,
-                    serial_number: x509_cert::serial_number::SerialNumber::new(&serial_number)
-                        .into_diagnostic()?,
-                    signature: signature_algorithm.clone(),
-                    issuer: issuer_dn,
-                    validity,
-                    subject: subject_entity.distinguished_name().clone(),
-                    subject_public_key_info: spki,
-                    issuer_unique_id: None,
-                    subject_unique_id: None,
-                    extensions: None,
-                };
-
-                if let Some(v) = &cert_config.extensions {
-                    for extension_config in v {
-                        let extension = <dyn Extension>::from_config(
-                            extension_config,
-                            &tbs_cert,
-                            issuer_cert.as_ref(),
-                        )?;
-
-                        let cert_extension = x509_cert::ext::Extension {
-                            extn_id: extension.oid(),
-                            critical: extension.is_critical(),
-                            extn_value: x509_cert::der::asn1::OctetString::new(extension.as_der())
-                                .into_diagnostic()?,
-                        };
-
-                        let mut ext_vec = if let Some(x) = tbs_cert.extensions {
-                            x.clone()
-                        } else {
-                            Vec::new()
-                        };
-                        ext_vec.push(cert_extension);
-                        tbs_cert.extensions = Some(ext_vec);
-                    }
-                }
-
-                let tbs_cert_der = tbs_cert.to_der().into_diagnostic()?;
-
-                let cert_signature = issuer_kp
-                    .signature(cert_config.digest_algorithm.as_ref(), &tbs_cert_der)
-                    .wrap_err("signing cert")?;
-                let cert = Certificate {
-                    tbs_certificate: tbs_cert,
-                    signature_algorithm: signature_algorithm.clone(),
-                    signature: BitString::from_bytes(&cert_signature).into_diagnostic()?,
-                };
-
-                let cert_filename = format!("{}.cert.pem", cert_config.name);
-                println!("Writing certificate to \"{}\"", &cert_filename);
-                write_to_file(
-                    &cert_filename,
-                    cert.to_pem(LineEnding::CRLF).into_diagnostic()?.as_bytes(),
-                    action_opts.output_exists,
-                )?
-            }
+            doc.write_certificates(dir, action_opts.output_exists)
         }
     }
-
-    Ok(())
 }

--- a/src/sprockets.rs
+++ b/src/sprockets.rs
@@ -1,0 +1,496 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Convenience mechanisms for generating trust quorum cert chains for testing
+
+use crate::{
+    config::{
+        AuthorityKeyIdentifierExtension, BasicConstraintsExtension, Certificate, CertificateList,
+        CertificatePoliciesExtension, CertificatePolicy, DiceTcbInfoExtension, DigestAlgorithm,
+        Document, Entity, EntityNameComponent, Fwid, KeyPair, KeyType, KeyUsageExtension,
+        SubjectKeyIdentifierExtension, X509Extensions,
+    },
+    ValidDocument,
+};
+
+fn test_root() -> (KeyPair, Entity, Certificate) {
+    let name = "test-root-a".to_string();
+    (
+        KeyPair {
+            name: name.clone(),
+            key_type: vec![KeyType::P384],
+        },
+        Entity {
+            name: name.clone(),
+            common_name: name.clone(),
+            base_dn: vec![
+                EntityNameComponent::CountryName("US".into()),
+                EntityNameComponent::OrganizationName("Oxide Computer Company".into()),
+            ],
+        },
+        Certificate {
+            name: name.clone(),
+            subject_entity: name.clone(),
+            subject_key: name.clone(),
+            issuer_entity: Some(name.clone()),
+            issuer_key: name.clone(),
+            issuer_certificate: None,
+            digest_algorithm: Some(DigestAlgorithm::Sha_384),
+            not_after: "9999-12-31T23:59:59Z".into(),
+            not_before: None,
+            serial_number: "00".into(),
+            extensions: Some(vec![
+                X509Extensions::SubjectKeyIdentifier(SubjectKeyIdentifierExtension {
+                    critical: false,
+                }),
+                X509Extensions::BasicConstraints(BasicConstraintsExtension {
+                    critical: true,
+                    ca: true,
+                    path_len: None,
+                }),
+                X509Extensions::KeyUsage(KeyUsageExtension {
+                    critical: true,
+                    key_cert_sign: true,
+                    crl_sign: true,
+                    digital_signature: false,
+                    non_repudiation: false,
+                    key_encipherment: false,
+                    data_encipherment: false,
+                    key_agreement: false,
+                    encipher_only: false,
+                    decipher_only: false,
+                }),
+                X509Extensions::CertificatePolicies(CertificatePoliciesExtension {
+                    critical: true,
+                    policies: vec![
+                        CertificatePolicy::OanaPlatformIdentity,
+                        CertificatePolicy::TcgDiceKpIdentityInit,
+                        CertificatePolicy::TcgDiceKpAttestInit,
+                        CertificatePolicy::TcgDiceKpEca,
+                    ],
+                }),
+            ]),
+        },
+    )
+}
+
+fn test_signer() -> (KeyPair, Entity, Certificate) {
+    let name = "test-signer-a1".to_string();
+    let issuer = "test-root-a".to_string();
+    (
+        KeyPair {
+            name: name.clone(),
+            key_type: vec![KeyType::P384],
+        },
+        Entity {
+            name: name.clone(),
+            common_name: name.clone(),
+            base_dn: vec![
+                EntityNameComponent::CountryName("US".into()),
+                EntityNameComponent::OrganizationName("Oxide Computer Company".into()),
+            ],
+        },
+        Certificate {
+            name: name.clone(),
+            subject_entity: name.clone(),
+            subject_key: name.clone(),
+            issuer_entity: None,
+            issuer_key: issuer.clone(),
+            issuer_certificate: Some(issuer.clone()),
+            digest_algorithm: Some(DigestAlgorithm::Sha_384),
+            not_after: "9999-12-31T23:59:59Z".into(),
+            not_before: None,
+            serial_number: "01".into(),
+            extensions: Some(vec![
+                X509Extensions::SubjectKeyIdentifier(SubjectKeyIdentifierExtension {
+                    critical: false,
+                }),
+                X509Extensions::AuthorityKeyIdentifier(AuthorityKeyIdentifierExtension {
+                    critical: false,
+                    key_id: true,
+                    issuer: false,
+                }),
+                X509Extensions::BasicConstraints(BasicConstraintsExtension {
+                    critical: true,
+                    ca: true,
+                    path_len: None,
+                }),
+                X509Extensions::KeyUsage(KeyUsageExtension {
+                    critical: true,
+                    key_cert_sign: true,
+                    crl_sign: true,
+                    digital_signature: false,
+                    non_repudiation: false,
+                    key_encipherment: false,
+                    data_encipherment: false,
+                    key_agreement: false,
+                    encipher_only: false,
+                    decipher_only: false,
+                }),
+                X509Extensions::CertificatePolicies(CertificatePoliciesExtension {
+                    critical: true,
+                    policies: vec![
+                        CertificatePolicy::OanaPlatformIdentity,
+                        CertificatePolicy::TcgDiceKpIdentityInit,
+                        CertificatePolicy::TcgDiceKpAttestInit,
+                        CertificatePolicy::TcgDiceKpEca,
+                    ],
+                }),
+            ]),
+        },
+    )
+}
+
+fn test_platformid(n: usize) -> (KeyPair, Entity, Certificate) {
+    let name = format!("test-platformid-{n}");
+    let issuer = "test-signer-a1".to_string();
+    (
+        KeyPair {
+            name: name.clone(),
+            key_type: vec![KeyType::Ed25519],
+        },
+        Entity {
+            name: name.clone(),
+            common_name: format!("PDV2:PPP-PPPPPPP:RRR:{n}"),
+            base_dn: vec![
+                EntityNameComponent::CountryName("US".into()),
+                EntityNameComponent::OrganizationName("Oxide Computer Company".into()),
+            ],
+        },
+        Certificate {
+            name: name.clone(),
+            subject_entity: name.clone(),
+            subject_key: name.clone(),
+            issuer_entity: None,
+            issuer_key: issuer.clone(),
+            issuer_certificate: Some(issuer.clone()),
+            digest_algorithm: Some(DigestAlgorithm::Sha_384),
+            not_after: "9999-12-31T23:59:59Z".into(),
+            not_before: None,
+            // We shouldn't be generating more than 1k platform IDs per test
+            serial_number: (1000 + n).to_string(),
+            extensions: Some(vec![
+                X509Extensions::SubjectKeyIdentifier(SubjectKeyIdentifierExtension {
+                    critical: false,
+                }),
+                X509Extensions::AuthorityKeyIdentifier(AuthorityKeyIdentifierExtension {
+                    critical: false,
+                    key_id: true,
+                    issuer: false,
+                }),
+                X509Extensions::BasicConstraints(BasicConstraintsExtension {
+                    critical: true,
+                    ca: true,
+                    path_len: None,
+                }),
+                X509Extensions::KeyUsage(KeyUsageExtension {
+                    critical: true,
+                    key_cert_sign: true,
+                    crl_sign: true,
+                    digital_signature: false,
+                    non_repudiation: false,
+                    key_encipherment: false,
+                    data_encipherment: false,
+                    key_agreement: false,
+                    encipher_only: false,
+                    decipher_only: false,
+                }),
+                X509Extensions::CertificatePolicies(CertificatePoliciesExtension {
+                    critical: true,
+                    policies: vec![
+                        CertificatePolicy::OanaPlatformIdentity,
+                        CertificatePolicy::TcgDiceKpIdentityInit,
+                        CertificatePolicy::TcgDiceKpAttestInit,
+                        CertificatePolicy::TcgDiceKpEca,
+                    ],
+                }),
+            ]),
+        },
+    )
+}
+
+fn test_deviceid(n: usize) -> (KeyPair, Entity, Certificate) {
+    let name = format!("test-deviceid-{n}");
+    let issuer = format!("test-platformid-{n}");
+    (
+        KeyPair {
+            name: name.clone(),
+            key_type: vec![KeyType::Ed25519],
+        },
+        Entity {
+            name: name.clone(),
+            common_name: name.clone(),
+            base_dn: vec![
+                EntityNameComponent::CountryName("US".into()),
+                EntityNameComponent::OrganizationName("Oxide Computer Company".into()),
+            ],
+        },
+        Certificate {
+            name: name.clone(),
+            subject_entity: name.clone(),
+            subject_key: name.clone(),
+            issuer_entity: None,
+            issuer_key: issuer.clone(),
+            issuer_certificate: Some(issuer.clone()),
+            digest_algorithm: Some(DigestAlgorithm::Sha_512),
+            not_after: "9999-12-31T23:59:59Z".into(),
+            not_before: None,
+            // We shouldn't be generating more than 1k device IDs per test
+            serial_number: (2000 + n).to_string(),
+            extensions: Some(vec![
+                X509Extensions::SubjectKeyIdentifier(SubjectKeyIdentifierExtension {
+                    critical: false,
+                }),
+                X509Extensions::AuthorityKeyIdentifier(AuthorityKeyIdentifierExtension {
+                    critical: false,
+                    key_id: true,
+                    issuer: false,
+                }),
+                X509Extensions::BasicConstraints(BasicConstraintsExtension {
+                    critical: true,
+                    ca: true,
+                    path_len: None,
+                }),
+                X509Extensions::KeyUsage(KeyUsageExtension {
+                    critical: true,
+                    key_cert_sign: true,
+                    crl_sign: true,
+                    digital_signature: false,
+                    non_repudiation: false,
+                    key_encipherment: false,
+                    data_encipherment: false,
+                    key_agreement: false,
+                    encipher_only: false,
+                    decipher_only: false,
+                }),
+                X509Extensions::CertificatePolicies(CertificatePoliciesExtension {
+                    critical: true,
+                    policies: vec![
+                        CertificatePolicy::OanaPlatformIdentity,
+                        CertificatePolicy::TcgDiceKpIdentityInit,
+                        CertificatePolicy::TcgDiceKpAttestInit,
+                        CertificatePolicy::TcgDiceKpEca,
+                    ],
+                }),
+            ]),
+        },
+    )
+}
+
+fn test_sprockets_auth(n: usize) -> (KeyPair, Entity, Certificate) {
+    let name = format!("test-sprockets-auth-{n}");
+    let issuer = format!("test-deviceid-{n}");
+    (
+        KeyPair {
+            name: name.clone(),
+            key_type: vec![KeyType::Ed25519],
+        },
+        Entity {
+            name: name.clone(),
+            common_name: name.clone(),
+            base_dn: vec![
+                EntityNameComponent::CountryName("US".into()),
+                EntityNameComponent::OrganizationName("Oxide Computer Company".into()),
+            ],
+        },
+        Certificate {
+            name: name.clone(),
+            subject_entity: name.clone(),
+            subject_key: name.clone(),
+            issuer_entity: None,
+            issuer_key: issuer.clone(),
+            issuer_certificate: Some(issuer.clone()),
+            digest_algorithm: Some(DigestAlgorithm::Sha_512),
+            not_after: "9999-12-31T23:59:59Z".into(),
+            not_before: None,
+            // We shouldn't be generating more than 1k sprockets auth keys per test
+            serial_number: (3000 + n).to_string(),
+            extensions: Some(vec![
+                X509Extensions::SubjectKeyIdentifier(SubjectKeyIdentifierExtension {
+                    critical: false,
+                }),
+                X509Extensions::AuthorityKeyIdentifier(AuthorityKeyIdentifierExtension {
+                    critical: false,
+                    key_id: true,
+                    issuer: false,
+                }),
+                X509Extensions::BasicConstraints(BasicConstraintsExtension {
+                    critical: true,
+                    ca: false,
+                    path_len: None,
+                }),
+                X509Extensions::KeyUsage(KeyUsageExtension {
+                    critical: true,
+                    key_cert_sign: false,
+                    crl_sign: false,
+                    digital_signature: true,
+                    non_repudiation: true,
+                    key_encipherment: false,
+                    data_encipherment: false,
+                    key_agreement: false,
+                    encipher_only: false,
+                    decipher_only: false,
+                }),
+                X509Extensions::CertificatePolicies(CertificatePoliciesExtension {
+                    critical: true,
+                    policies: vec![
+                        CertificatePolicy::OanaPlatformIdentity,
+                        CertificatePolicy::TcgDiceKpIdentityInit,
+                        CertificatePolicy::TcgDiceKpAttestInit,
+                        CertificatePolicy::TcgDiceKpEca,
+                    ],
+                }),
+            ]),
+        },
+    )
+}
+
+fn test_sprockets_auth_certificate_list(n: usize) -> CertificateList {
+    let name = format!("test-sprockets-auth-{n}");
+    CertificateList {
+        name: name.clone(),
+        certificates: vec![
+            name,
+            format!("test-deviceid-{n}"),
+            format!("test-platformid-{n}"),
+            format!("test-signer-a1"),
+        ],
+    }
+}
+
+fn test_alias(n: usize) -> (KeyPair, Entity, Certificate) {
+    let name = format!("test-alias-{n}");
+    let issuer = format!("test-deviceid-{n}");
+    (
+        KeyPair {
+            name: name.clone(),
+            key_type: vec![KeyType::Ed25519],
+        },
+        Entity {
+            name: name.clone(),
+            common_name: "alias".to_string(),
+            base_dn: vec![
+                EntityNameComponent::CountryName("US".into()),
+                EntityNameComponent::OrganizationName("Oxide Computer Company".into()),
+            ],
+        },
+        Certificate {
+            name: name.clone(),
+            subject_entity: name.clone(),
+            subject_key: name.clone(),
+            issuer_entity: None,
+            issuer_key: issuer.clone(),
+            issuer_certificate: Some(issuer.clone()),
+            digest_algorithm: None,
+            not_after: "9999-12-31T23:59:59Z".into(),
+            not_before: None,
+            // We shouldn't be generating more than 1k sprockets auth keys per test
+            serial_number: "00".to_string(),
+            extensions: Some(vec![
+                X509Extensions::BasicConstraints(BasicConstraintsExtension {
+                    critical: true,
+                    ca: false,
+                    path_len: None,
+                }),
+                X509Extensions::KeyUsage(KeyUsageExtension {
+                    critical: true,
+                    key_cert_sign: false,
+                    crl_sign: false,
+                    digital_signature: true,
+                    non_repudiation: false,
+                    key_encipherment: false,
+                    data_encipherment: false,
+                    key_agreement: false,
+                    encipher_only: false,
+                    decipher_only: false,
+                }),
+                X509Extensions::CertificatePolicies(CertificatePoliciesExtension {
+                    critical: true,
+                    policies: vec![CertificatePolicy::TcgDiceKpAttestInit],
+                }),
+                X509Extensions::DiceTcbInfo(DiceTcbInfoExtension {
+                    critical: true,
+                    fwid_list: vec![Fwid {
+                        digest_algorithm: DigestAlgorithm::Sha3_256,
+                        digest: "72fa8f8ea84a42251031366002cbb36281d0131f78cd680436116a720cdd9de5"
+                            .to_string(),
+                    }],
+                }),
+            ]),
+        },
+    )
+}
+
+fn test_alias_certificate_list(n: usize) -> CertificateList {
+    let name = format!("test-alias-{n}");
+    CertificateList {
+        name: name.clone(),
+        certificates: vec![
+            name,
+            format!("test-deviceid-{n}"),
+            format!("test-platformid-{n}"),
+            format!("test-signer-a1"),
+        ],
+    }
+}
+
+pub fn generate_config(num_nodes: usize) -> ValidDocument {
+    let root = test_root();
+    let signer = test_signer();
+    let mut doc = Document {
+        key_pairs: vec![root.0, signer.0],
+        entities: vec![root.1, signer.1],
+        certificates: vec![root.2, signer.2],
+        certificate_requests: vec![],
+        certificate_lists: vec![],
+    };
+    for i in 1..=num_nodes {
+        let platformid = test_platformid(i);
+        let device_id = test_deviceid(i);
+        let sprockets_auth = test_sprockets_auth(i);
+        let alias = test_alias(i);
+
+        doc.key_pairs.push(platformid.0);
+        doc.key_pairs.push(device_id.0);
+        doc.key_pairs.push(sprockets_auth.0);
+        doc.key_pairs.push(alias.0);
+
+        doc.entities.push(platformid.1);
+        doc.entities.push(device_id.1);
+        doc.entities.push(sprockets_auth.1);
+        doc.entities.push(alias.1);
+
+        doc.certificates.push(platformid.2);
+        doc.certificates.push(device_id.2);
+        doc.certificates.push(sprockets_auth.2);
+        doc.certificates.push(alias.2);
+
+        doc.certificate_lists
+            .push(test_sprockets_auth_certificate_list(i));
+        doc.certificate_lists.push(test_alias_certificate_list(i));
+    }
+
+    ValidDocument::validate(doc).expect("validation succeeds")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_config;
+    use crate::config;
+    use camino::Utf8PathBuf;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    pub fn sprockets_example_matches_code_based_generation() {
+        let path = Utf8PathBuf::from(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/sprockets/config.kdl"
+        ));
+
+        let loaded = config::load_and_validate(&path).expect("config loads and validates");
+        let generated = generate_config(2);
+
+        assert_eq!(loaded, generated);
+    }
+}

--- a/src/valid_document.rs
+++ b/src/valid_document.rs
@@ -1,0 +1,530 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::{Entity, Extension, KeyPair};
+use camino::Utf8PathBuf;
+use clap::ValueEnum;
+use miette::{miette, Context, IntoDiagnostic, Result};
+use pem_rfc7468::LineEnding;
+use spki::SubjectPublicKeyInfo;
+use std::collections::{HashMap, HashSet};
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::str::FromStr;
+use std::time::SystemTime;
+use x509_cert::{
+    attr::Attributes,
+    der::{
+        asn1::{BitString, GeneralizedTime, UtcTime},
+        DateTime, Decode, DecodePem, Encode, EncodePem,
+    },
+    request::{CertReq, CertReqInfo},
+    time::Validity,
+    Certificate, TbsCertificate,
+};
+
+use crate::config;
+
+/// An identical structure to `Document` that has already been validated.
+///
+/// Importantly, this type does not derive knuffel types, because it
+/// isn't ever read from the KDL directly. It can only be created by the
+/// `validate_document` function.
+///
+/// In order to prevent mutation, all fields on a `ValidDocument` are private.
+///
+/// https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
+#[derive(Debug, PartialEq, Eq)]
+pub struct ValidDocument {
+    key_pairs: Vec<config::KeyPair>,
+    entities: Vec<config::Entity>,
+    certificates: Vec<config::Certificate>,
+    certificate_requests: Vec<config::CertificateRequest>,
+    certificate_lists: Vec<config::CertificateList>,
+}
+
+impl ValidDocument {
+    pub fn write_key_pairs(&self, dir: Utf8PathBuf, opts: OutputFileExistsBehavior) -> Result<()> {
+        for kp_config in &self.key_pairs {
+            let kp = <dyn KeyPair>::new(kp_config)?;
+            let kp_filename = format!("{}.key.pem", kp_config.name);
+            let path = dir.join(&kp_filename);
+            println!("Writing key pair to \"{}\"", &path);
+            write_to_file(&path, kp.to_pkcs8_pem()?.as_bytes(), opts)?
+        }
+        Ok(())
+    }
+
+    pub fn write_certificate_lists(
+        &self,
+        dir: Utf8PathBuf,
+        opts: OutputFileExistsBehavior,
+    ) -> Result<()> {
+        let certificates = self.load_certificates(dir.clone())?;
+        for certlist_cfg in &self.certificate_lists {
+            let mut cert_chain = String::new();
+            let certlist_filename = format!("{}.certlist.pem", certlist_cfg.name);
+            let path = dir.join(&certlist_filename);
+            println!("Writing pki path to \"{}\"", &path);
+            for cert_name in &certlist_cfg.certificates {
+                let cert = certificates.get(cert_name).ok_or(miette!(
+                    "Certificate does not exist: {}",
+                    &certlist_cfg.name
+                ))?;
+                cert_chain += &cert.to_pem(LineEnding::CRLF).into_diagnostic()?;
+            }
+            write_to_file(&path, cert_chain.as_bytes(), opts)?
+        }
+        Ok(())
+    }
+
+    pub fn write_certificate_requests(
+        &self,
+        dir: Utf8PathBuf,
+        opts: OutputFileExistsBehavior,
+    ) -> Result<()> {
+        let key_pairs = self.load_keypairs(dir.clone())?;
+        let entities = self.load_entities()?;
+
+        for csr_config in &self.certificate_requests {
+            let subject_kp = key_pairs.get(&csr_config.subject_key).ok_or(miette!(
+                "Subject key does not exist: {}",
+                &csr_config.subject_key
+            ))?;
+            let public_key = SubjectPublicKeyInfo::from_der(subject_kp.to_spki()?.as_bytes())
+                .into_diagnostic()?;
+
+            let subject = entities.get(&csr_config.subject_entity).ok_or(miette!(
+                "Entity does not exist: {}",
+                &csr_config.subject_entity
+            ))?;
+            let subject = subject.distinguished_name().clone();
+
+            let info = CertReqInfo {
+                version: x509_cert::request::Version::V1,
+                subject,
+                public_key,
+                attributes: Attributes::default(),
+            };
+            let info_der = info.to_der().into_diagnostic()?;
+
+            let signature = subject_kp
+                .signature(csr_config.digest_algorithm.as_ref(), &info_der)
+                .wrap_err("Failed to sign CSR info structure")?;
+            let signature = BitString::from_bytes(&signature).into_diagnostic()?;
+
+            let algorithm = csr_config.digest_algorithm.as_ref();
+            let algorithm = subject_kp.signature_algorithm(algorithm)?;
+
+            let csr = CertReq {
+                info,
+                algorithm,
+                signature,
+            };
+
+            let csr_filename = format!("{}.csr.pem", csr_config.name);
+            let path = dir.join(&csr_filename);
+            println!("Writing certificate request to \"{}\"", &path);
+            write_to_file(
+                &path,
+                csr.to_pem(LineEnding::CRLF).into_diagnostic()?.as_bytes(),
+                opts,
+            )?
+        }
+
+        Ok(())
+    }
+
+    pub fn write_certificates(
+        &self,
+        dir: Utf8PathBuf,
+        opts: OutputFileExistsBehavior,
+    ) -> Result<()> {
+        let key_pairs = self.load_keypairs(dir.clone())?;
+        let entities = self.load_entities()?;
+
+        for cert_config in &self.certificates {
+            let subject_entity = entities.get(&cert_config.subject_entity).ok_or(miette!(
+                "Subject entity for certificate {} does not exist: {}",
+                &cert_config.name,
+                &cert_config.subject_entity,
+            ))?;
+            let subject_kp = key_pairs.get(&cert_config.subject_key).ok_or(miette!(
+                "Subject key pair for certificate {} does not exist: {}",
+                &cert_config.name,
+                &cert_config.subject_key,
+            ))?;
+
+            let issuer_cert_pem = if let Some(issuer_cert_name) = &cert_config.issuer_certificate {
+                let issuer_cert_filename = format!("{}.cert.pem", issuer_cert_name);
+                let mut issuer_cert_pem = Vec::new();
+                let mut issuer_cert_file = std::fs::File::open(&issuer_cert_filename)
+                    .into_diagnostic()
+                    .wrap_err(format!(
+                        "Unable to load issuer certificate \"{}\" from file \"{}\"",
+                        issuer_cert_name, issuer_cert_filename
+                    ))?;
+                issuer_cert_file
+                    .read_to_end(&mut issuer_cert_pem)
+                    .into_diagnostic()?;
+                Some(issuer_cert_pem)
+            } else {
+                None
+            };
+
+            let issuer_cert = if let Some(issuer_cert_pem) = &issuer_cert_pem {
+                Some(x509_cert::Certificate::from_pem(issuer_cert_pem).into_diagnostic()?)
+            } else {
+                None
+            };
+
+            let issuer_dn = if let Some(issuer_cert) = &issuer_cert {
+                issuer_cert.tbs_certificate.subject.clone()
+            } else {
+                entities
+                    .get(cert_config.issuer_entity.as_ref().unwrap())
+                    .unwrap()
+                    .distinguished_name()
+                    .clone()
+            };
+
+            let issuer_kp = key_pairs.get(&cert_config.issuer_key).ok_or(miette!(
+                "Issuer key does not exist: {}",
+                &cert_config.issuer_key
+            ))?;
+
+            let not_after = DateTime::from_str(&cert_config.not_after).into_diagnostic()?;
+            let not_after = if not_after.year() >= 2050 {
+                GeneralizedTime::from(not_after).into()
+            } else {
+                UtcTime::try_from(not_after).into_diagnostic()?.into()
+            };
+            let not_before = match &cert_config.not_before {
+                None => DateTime::from_system_time(SystemTime::now()).into_diagnostic()?,
+                Some(x) => DateTime::from_str(x).into_diagnostic()?,
+            };
+            let not_before = if not_before.year() >= 2050 {
+                GeneralizedTime::from(not_before).into()
+            } else {
+                UtcTime::try_from(not_before).into_diagnostic()?.into()
+            };
+
+            let validity = Validity {
+                not_before,
+                not_after,
+            };
+
+            let signature_algorithm =
+                issuer_kp.signature_algorithm(cert_config.digest_algorithm.as_ref())?;
+
+            let spki_der = subject_kp.to_spki()?;
+            let spki = SubjectPublicKeyInfo::from_der(spki_der.as_bytes()).into_diagnostic()?;
+
+            let serial_number = hex::decode(&cert_config.serial_number)
+                .into_diagnostic()
+                .wrap_err(format!(
+                    "Serial number of certificate \"{}\"",
+                    cert_config.name
+                ))?;
+            if serial_number.len() > 20 {
+                return Err(miette::miette!(
+                    "Certificate serial number must be at most 20 octets"
+                ));
+            }
+
+            let mut tbs_cert = TbsCertificate {
+                version: x509_cert::Version::V3,
+                serial_number: x509_cert::serial_number::SerialNumber::new(&serial_number)
+                    .into_diagnostic()?,
+                signature: signature_algorithm.clone(),
+                issuer: issuer_dn,
+                validity,
+                subject: subject_entity.distinguished_name().clone(),
+                subject_public_key_info: spki,
+                issuer_unique_id: None,
+                subject_unique_id: None,
+                extensions: None,
+            };
+
+            if let Some(v) = &cert_config.extensions {
+                for extension_config in v {
+                    let extension = <dyn Extension>::from_config(
+                        extension_config,
+                        &tbs_cert,
+                        issuer_cert.as_ref(),
+                    )?;
+
+                    let cert_extension = x509_cert::ext::Extension {
+                        extn_id: extension.oid(),
+                        critical: extension.is_critical(),
+                        extn_value: x509_cert::der::asn1::OctetString::new(extension.as_der())
+                            .into_diagnostic()?,
+                    };
+
+                    let mut ext_vec = if let Some(x) = tbs_cert.extensions {
+                        x.clone()
+                    } else {
+                        Vec::new()
+                    };
+                    ext_vec.push(cert_extension);
+                    tbs_cert.extensions = Some(ext_vec);
+                }
+            }
+
+            let tbs_cert_der = tbs_cert.to_der().into_diagnostic()?;
+
+            let cert_signature = issuer_kp
+                .signature(cert_config.digest_algorithm.as_ref(), &tbs_cert_der)
+                .wrap_err("signing cert")?;
+            let cert = Certificate {
+                tbs_certificate: tbs_cert,
+                signature_algorithm: signature_algorithm.clone(),
+                signature: BitString::from_bytes(&cert_signature).into_diagnostic()?,
+            };
+
+            let cert_filename = format!("{}.cert.pem", cert_config.name);
+            let path = dir.join(&cert_filename);
+            println!("Writing certificate to \"{}\"", &path);
+            write_to_file(
+                &path,
+                cert.to_pem(LineEnding::CRLF).into_diagnostic()?.as_bytes(),
+                opts,
+            )?
+        }
+
+        Ok(())
+    }
+
+    fn load_keypairs(&self, dir: Utf8PathBuf) -> Result<HashMap<String, Box<dyn KeyPair>>> {
+        let mut key_pairs = HashMap::new();
+
+        for kp_config in &self.key_pairs {
+            let kp_filename = format!("{}.key.pem", kp_config.name);
+            let path = dir.join(&kp_filename);
+            let kp_pem = std::fs::read_to_string(&path)
+                .into_diagnostic()
+                .wrap_err(format!(
+                    "Unable to load key pair \"{}\" from \"{}\"",
+                    kp_config.name, &path
+                ))?;
+            let kp = <dyn KeyPair>::from_pem(kp_config, &kp_pem)?;
+            key_pairs.insert(String::from(kp.name()), kp);
+        }
+
+        Ok(key_pairs)
+    }
+
+    fn load_certificates(
+        &self,
+        dir: Utf8PathBuf,
+    ) -> Result<HashMap<String, x509_cert::Certificate>> {
+        let mut certs = HashMap::new();
+
+        for cert_cfg in &self.certificates {
+            let cert_filename = format!("{}.cert.pem", cert_cfg.name);
+            let path = dir.join(&cert_filename);
+            let cert_pem = std::fs::read_to_string(&path)
+                .into_diagnostic()
+                .wrap_err(format!(
+                    "Unable to load certificate \"{}\" from \"{}\"",
+                    cert_cfg.name, &path
+                ))?;
+            let cert = x509_cert::Certificate::from_pem(cert_pem).into_diagnostic()?;
+            certs.insert(cert_cfg.name.clone(), cert);
+        }
+
+        Ok(certs)
+    }
+
+    fn load_entities(&self) -> Result<HashMap<String, Entity>> {
+        let mut entity_map = HashMap::new();
+
+        for entity_config in &self.entities {
+            let entity = Entity::try_from(entity_config)?;
+            entity_map.insert(String::from(entity.name()), entity);
+        }
+
+        Ok(entity_map)
+    }
+
+    pub fn validate(doc: config::Document) -> Result<ValidDocument> {
+        let mut kp_names: HashSet<&str> = HashSet::new();
+        for kp in &doc.key_pairs {
+            if kp.key_type.len() != 1 {
+                miette::bail!(
+                    "key pairs must have exactly one key type. key pair \"{}\" has {}.",
+                    kp.name,
+                    kp.key_type.len()
+                );
+            }
+            if !kp_names.insert(&kp.name) {
+                miette::bail!(
+                    "key pairs must have unique names. \"{}\" is used more than once.",
+                    kp.name
+                )
+            }
+        }
+
+        let mut entity_names: HashSet<&str> = HashSet::new();
+        for entity in &doc.entities {
+            if !entity_names.insert(&entity.name) {
+                miette::bail!(
+                    "entities must have unique names. \"{}\" is used more than once.",
+                    entity.name
+                )
+            }
+        }
+
+        // Certificates can name other certificates as their issuer so need to
+        // gather all the names before checking validity.
+        let mut cert_names: HashSet<&str> = HashSet::new();
+        for cert in &doc.certificates {
+            if !cert_names.insert(&cert.name) {
+                miette::bail!(
+                    "certificates must have unique names. \"{}\" is used more than once.",
+                    cert.name
+                )
+            }
+        }
+
+        for cert in &doc.certificates {
+            if !entity_names.contains(cert.subject_entity.as_str()) {
+                miette::bail!(
+                    "certificate \"{}\" subject entity \"{}\" does not exist",
+                    cert.name,
+                    cert.subject_key
+                )
+            }
+
+            if !kp_names.contains(cert.subject_key.as_str()) {
+                miette::bail!(
+                    "certificate \"{}\" subject key pair \"{}\" does not exist",
+                    cert.name,
+                    cert.subject_key
+                )
+            }
+
+            match (&cert.issuer_entity, &cert.issuer_certificate) {
+            (None, None) => miette::bail!("certificate \"{}\" must specify either an issuer entity or certificate", cert.name),
+            (Some(_), Some(_)) => miette::bail!("certificate \"{}\" specifies both an issuer entity and certificate.  Only one may be specified.", cert.name),
+            (Some(entity), None) => {
+                if !entity_names.contains(entity.as_str()) {
+                    miette::bail!(
+                        "certificate \"{}\" issuer entity \"{}\" does not exist",
+                        cert.name,
+                        cert.issuer_key
+                    )
+                }
+            }
+            (None, Some(cert_name)) => {
+                if !cert_names.contains(cert_name.as_str()) {
+                    miette::bail!(
+                        "certificate \"{}\" issuer certificate \"{}\" does not exist",
+                        cert.name,
+                        cert.issuer_key
+                    )
+                }
+            }
+        }
+
+            if !kp_names.contains(cert.issuer_key.as_str()) {
+                miette::bail!(
+                    "certificate \"{}\" issuer key pair \"{}\" does not exist",
+                    cert.name,
+                    cert.issuer_key
+                )
+            }
+        }
+
+        let mut csr_names: HashSet<&str> = HashSet::new();
+        for csr in &doc.certificate_requests {
+            if !csr_names.insert(&csr.name) {
+                miette::bail!(
+                    "certificate requests must have unique names. \"{}\" is used more than once.",
+                    csr.name
+                )
+            }
+        }
+
+        for csr in &doc.certificate_requests {
+            if !entity_names.contains(csr.subject_entity.as_str()) {
+                miette::bail!(
+                    "certificate request \"{}\" subject entity \"{}\" does not exist",
+                    csr.name,
+                    csr.subject_key
+                )
+            }
+
+            if !kp_names.contains(csr.subject_key.as_str()) {
+                miette::bail!(
+                    "certificate request \"{}\" subject key pair \"{}\" does not exist",
+                    csr.name,
+                    csr.subject_key
+                )
+            }
+        }
+
+        for certlist in &doc.certificate_lists {
+            for cert in &certlist.certificates {
+                if !cert_names.contains(cert.as_str()) {
+                    miette::bail!("certificate \"{}\" does not exist", cert,)
+                }
+            }
+        }
+
+        let config::Document {
+            key_pairs,
+            entities,
+            certificates,
+            certificate_requests,
+            certificate_lists,
+        } = doc;
+
+        Ok(ValidDocument {
+            key_pairs,
+            entities,
+            certificates,
+            certificate_requests,
+            certificate_lists,
+        })
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, ValueEnum)]
+pub enum OutputFileExistsBehavior {
+    Skip,
+    Error,
+    Overwrite,
+}
+
+pub fn write_to_file(
+    path: &Utf8PathBuf,
+    contents: &[u8],
+    exists_behavior: OutputFileExistsBehavior,
+) -> Result<()> {
+    let mut open_opts = OpenOptions::new();
+    open_opts.write(true);
+    match exists_behavior {
+        OutputFileExistsBehavior::Skip | OutputFileExistsBehavior::Error => {
+            open_opts.create_new(true)
+        }
+        OutputFileExistsBehavior::Overwrite => open_opts.create(true).truncate(true),
+    };
+
+    let mut file = match open_opts.open(path) {
+        Err(e)
+            if e.kind() == std::io::ErrorKind::AlreadyExists
+                && exists_behavior == OutputFileExistsBehavior::Skip =>
+        {
+            println!("File \"{}\" already exists, skipping", path);
+            return Ok(());
+        }
+        x => x
+            .into_diagnostic()
+            .wrap_err(format!("Unable to open file \"{}\" for writing", path))?,
+    };
+    file.write_all(contents)
+        .into_diagnostic()
+        .wrap_err(format!("Unable to write to file \"{}\"", path))
+}


### PR DESCRIPTION
Fixes #85

This PR makes two changes that allow this code to act as a library and better support testing in other software like Omicron and Sprockets.

  1. It moves all the logic for validating a `Document` and writing files out of `main.rs` and into `ValidDocument.rs`.
  2. It provides support for programatically generating sprockets configs. Correctness is checked via a test that compares the example config copied over from the sprockets repo with one generated by the new `sprockets::generate_config` API. To make this work, I modified the serial numbers in the example to be match the generation scheme.

I made some other small changes to better support a library like allowing a path to be input in certain places. Relatedly, I changed to use `camino` rather than `std::path` like most of our other software.